### PR TITLE
fix(docker): Tags latest et stable manquants

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,5 +77,5 @@ jobs:
           password: ${{ secrets.OPT_DOCKERHUB_PASSWORD }}
 
       - name: Push docker image to Docker Hub
-        run: docker push optnc/colisnc-api:${{ steps.image_tags.outputs.version }}
+        run: docker push --all-tags optnc/colisnc-api:${{ steps.image_tags.outputs.version }}
 


### PR DESCRIPTION
Lors de la release, les tags autres que le principal (version) n'étaient pas positionnées